### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -118,7 +118,7 @@ def _demux(seqs, barcodes, error_tolerance, untrimmed):
 
 def demux_single(seqs: MultiplexedSingleEndBarcodeInSequenceDirFmt,
                  barcodes: qiime2.CategoricalMetadataColumn,
-                 error_rate: float=0.1) -> \
+                 error_rate: float = 0.1) -> \
                     (CasavaOneEightSingleLanePerSampleDirFmt,
                      MultiplexedSingleEndBarcodeInSequenceDirFmt):
 
@@ -128,7 +128,7 @@ def demux_single(seqs: MultiplexedSingleEndBarcodeInSequenceDirFmt,
 
 def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
                  forward_barcodes: qiime2.CategoricalMetadataColumn,
-                 error_rate: float=0.1) -> \
+                 error_rate: float = 0.1) -> \
                     (CasavaOneEightSingleLanePerSampleDirFmt,
                      MultiplexedPairedEndBarcodeInSequenceDirFmt):
 

--- a/q2_cutadapt/_trim.py
+++ b/q2_cutadapt/_trim.py
@@ -113,18 +113,18 @@ def _build_trim_command(f_read, r_read, trimmed_seqs,
 
 def trim_single(demultiplexed_sequences:
                 SingleLanePerSampleSingleEndFastqDirFmt,
-                cores: int=_trim_defaults['cores'],
-                adapter: str=_trim_defaults['adapter_f'],
-                front: str=_trim_defaults['front_f'],
-                anywhere: str=_trim_defaults['anywhere_f'],
-                error_rate: float=_trim_defaults['error_rate'],
-                indels: bool=_trim_defaults['indels'],
-                times: int=_trim_defaults['times'],
-                overlap: int=_trim_defaults['overlap'],
+                cores: int = _trim_defaults['cores'],
+                adapter: str = _trim_defaults['adapter_f'],
+                front: str = _trim_defaults['front_f'],
+                anywhere: str = _trim_defaults['anywhere_f'],
+                error_rate: float = _trim_defaults['error_rate'],
+                indels: bool = _trim_defaults['indels'],
+                times: int = _trim_defaults['times'],
+                overlap: int = _trim_defaults['overlap'],
                 match_read_wildcards:
-                bool=_trim_defaults['match_read_wildcards'],
+                bool = _trim_defaults['match_read_wildcards'],
                 match_adapter_wildcards:
-                bool=_trim_defaults['match_adapter_wildcards']) -> \
+                bool = _trim_defaults['match_adapter_wildcards']) -> \
                     CasavaOneEightSingleLanePerSampleDirFmt:
     trimmed_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     cmds = []
@@ -143,21 +143,21 @@ def trim_single(demultiplexed_sequences:
 
 def trim_paired(demultiplexed_sequences:
                 SingleLanePerSamplePairedEndFastqDirFmt,
-                cores: int=_trim_defaults['cores'],
-                adapter_f: str=_trim_defaults['adapter_f'],
-                front_f: str=_trim_defaults['front_f'],
-                anywhere_f: str=_trim_defaults['anywhere_f'],
-                adapter_r: str=_trim_defaults['adapter_r'],
-                front_r: str=_trim_defaults['front_r'],
-                anywhere_r: str=_trim_defaults['anywhere_r'],
-                error_rate: float=_trim_defaults['error_rate'],
-                indels: bool=_trim_defaults['indels'],
-                times: int=_trim_defaults['times'],
-                overlap: int=_trim_defaults['overlap'],
+                cores: int = _trim_defaults['cores'],
+                adapter_f: str = _trim_defaults['adapter_f'],
+                front_f: str = _trim_defaults['front_f'],
+                anywhere_f: str = _trim_defaults['anywhere_f'],
+                adapter_r: str = _trim_defaults['adapter_r'],
+                front_r: str = _trim_defaults['front_r'],
+                anywhere_r: str = _trim_defaults['anywhere_r'],
+                error_rate: float = _trim_defaults['error_rate'],
+                indels: bool = _trim_defaults['indels'],
+                times: int = _trim_defaults['times'],
+                overlap: int = _trim_defaults['overlap'],
                 match_read_wildcards:
-                bool=_trim_defaults['match_read_wildcards'],
+                bool = _trim_defaults['match_read_wildcards'],
                 match_adapter_wildcards:
-                bool=_trim_defaults['match_adapter_wildcards']) -> \
+                bool = _trim_defaults['match_adapter_wildcards']) -> \
                     CasavaOneEightSingleLanePerSampleDirFmt:
     trimmed_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     cmds = []

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.