### PR TITLE
Fix issue request #49

### DIFF
--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -121,7 +121,7 @@ def _write_empty_fastq_to_mux_barcode_in_seq_fmt(seqs_dir_fmt):
 
 
 def _demux(seqs, per_sample_sequences, forward_barcodes, reverse_barcodes,
-           error_tolerance, mux_fmt, batch_size, minimum_length,cores):
+           error_tolerance, mux_fmt, batch_size, minimum_length, cores):
     fwd_barcode_name = forward_barcodes.name
     forward_barcodes = forward_barcodes.drop_missing_values()
     barcodes = forward_barcodes.to_series().to_frame()
@@ -191,12 +191,12 @@ def _demux(seqs, per_sample_sequences, forward_barcodes, reverse_barcodes,
 
 def demux_single(seqs: MultiplexedSingleEndBarcodeInSequenceDirFmt,
                  barcodes: qiime2.CategoricalMetadataColumn,
-                 cores: int = 1,
                  error_rate: float = 0.1,
                  batch_size: int = 0,
-                 minimum_length: int = 1) -> \
-                    (CasavaOneEightSingleLanePerSampleDirFmt,
-                     MultiplexedSingleEndBarcodeInSequenceDirFmt):
+                 minimum_length: int = 1,
+                 cores: int = 1) -> \
+                 (CasavaOneEightSingleLanePerSampleDirFmt,
+                  MultiplexedSingleEndBarcodeInSequenceDirFmt):
     per_sample_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     mux_fmt = MultiplexedSingleEndBarcodeInSequenceDirFmt
 
@@ -208,15 +208,16 @@ def demux_single(seqs: MultiplexedSingleEndBarcodeInSequenceDirFmt,
 
 
 def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
-                 cores: int = 1,
                  forward_barcodes: qiime2.CategoricalMetadataColumn,
                  reverse_barcodes: qiime2.CategoricalMetadataColumn = None,
                  error_rate: float = 0.1,
                  batch_size: int = 0,
                  minimum_length: int = 1,
-                 mixed_orientation: bool = False) -> \
+                 mixed_orientation: bool = False,
+                 cores: int = 1) -> \
                     (CasavaOneEightSingleLanePerSampleDirFmt,
-                     MultiplexedPairedEndBarcodeInSequenceDirFmt):
+                     MultiplexedPairedEndBarcodeInSequenceDirFmt,
+                 ):
     if mixed_orientation and reverse_barcodes is not None:
         raise ValueError('Dual-indexed barcodes for mixed orientation '
                          'reads are not supported.')
@@ -226,7 +227,7 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
 
     untrimmed = _demux(
         seqs, per_sample_sequences, forward_barcodes, reverse_barcodes,
-        error_rate, mux_fmt, batch_size, minimum_length)
+        error_rate, mux_fmt, batch_size, minimum_length,cores)
 
     if mixed_orientation:
         fwd = untrimmed.forward_sequences.view(FastqGzFormat)

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -233,6 +233,7 @@ plugin.methods.register_function(
                                     inclusive_end=True),
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
+        'cores': Int % Range(1, None),
     },
     outputs=[
         ('per_sample_sequences', SampleData[SequencesWithQuality]),
@@ -242,6 +243,7 @@ plugin.methods.register_function(
         'seqs': 'The single-end sequences to be demultiplexed.',
     },
     parameter_descriptions={
+        'cores': 'Number of CPU cores to use.',
         'barcodes': 'The sample metadata column listing the per-sample '
                     'barcodes.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
@@ -283,6 +285,7 @@ plugin.methods.register_function(
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
         'mixed_orientation': Bool,
+        'cores': Int % Range(1, None),
     },
     outputs=[
         ('per_sample_sequences', SampleData[PairedEndSequencesWithQuality]),
@@ -292,6 +295,7 @@ plugin.methods.register_function(
         'seqs': 'The paired-end sequences to be demultiplexed.',
     },
     parameter_descriptions={
+        'cores': 'Number of CPU cores to use.',
         'forward_barcodes': 'The sample metadata column listing the '
                             'per-sample barcodes for the forward reads.',
         'reverse_barcodes': 'The sample metadata column listing the '


### PR DESCRIPTION
This is fixing Issue #49 which adds multicore support to the paired demux command.  Previously cutadapt did not support multicore runs but v3.0 does with the `-j CORES` parameter. 

This speeds up demux dramatically by the factor of the number of cores. A single Miseq run takes 3-4 hrs on a single-threaded run and ~20mins with 96 cores.

This addition just adds the parameter `--p-cores` but if this is left off it should default to 1.  An option is to default to `0` 