### PR TITLE
Expose cutadapt `--cut` option

### DIFF
--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -290,8 +290,10 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
         remaining_seqs.reverse_sequences.write_data(fwd, FastqGzFormat)
 
         # we have two "cut" cases possible:
-        #  - no reverse barcode was provided and the cut was only applied to the forward sequences
-        #  - reverse barcodes were provided and the cut was applied on both sequences
+        #  - no reverse barcode was provided and the cut was only applied to
+        #    the forward sequences
+        #  - reverse barcodes were provided and the cut was applied on both
+        #    sequences
         if reverse_barcodes is None:
             # apply cut to the new forward strand
             untrimmed = _demux(

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -288,9 +288,10 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
         remaining_seqs.forward_sequences.write_data(rev, FastqGzFormat)
         remaining_seqs.reverse_sequences.write_data(fwd, FastqGzFormat)
 
+        # set cut to 0 as sequences have already been cut
         untrimmed = _demux(
             remaining_seqs, per_sample_sequences, forward_barcodes,
             reverse_barcodes, error_rate, mux_fmt, batch_size,
-            minimum_length, cut, cores)
+            minimum_length, 0, cores)
 
     return per_sample_sequences, untrimmed

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -280,8 +280,9 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
         mixed_orientation
         and forward_cut != reverse_cut
     ):
-        raise ValueError("'forward_cut' and 'reverse_cut' need to be set to the"
-                         "same number when using the 'mixed_orientation' mode")
+        raise ValueError("'forward_cut' and 'reverse_cut' need to be set to "
+                         "the same number when using the 'mixed_orientation' "
+                         "mode")
 
     per_sample_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     mux_fmt = MultiplexedPairedEndBarcodeInSequenceDirFmt
@@ -305,6 +306,5 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
             remaining_seqs, per_sample_sequences, forward_barcodes,
             reverse_barcodes, error_rate, mux_fmt, batch_size,
             minimum_length, 0, 0, cores)
-
 
     return per_sample_sequences, untrimmed

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -348,7 +348,7 @@ plugin.methods.register_function(
                        'from the beginning of the sequences. If a negative '
                        'value is provided, bases are removed from the end of '
                        'the sequences. If --p-mixed-orientation is set, then '
-                       'both --p-forward-cut and --p-reverse-cut must both be '
+                       'both --p-forward-cut and --p-reverse-cut must be '
                        'set to the same value.',
         'reverse_cut': 'Remove the specified number of bases from the reverse '
                        'sequences. Bases are removed before demultiplexing. '
@@ -356,7 +356,7 @@ plugin.methods.register_function(
                        'from the beginning of the sequences. If a negative '
                        'value is provided, bases are removed from the end of '
                        'the sequences. If --p-mixed-orientation is set, then '
-                       'both --p-forward-cut and --p-reverse-cut must both be '
+                       'both --p-forward-cut and --p-reverse-cut must be '
                        'set to the same value.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -343,17 +343,17 @@ plugin.methods.register_function(
         'reverse_barcodes': 'The sample metadata column listing the '
                             'per-sample barcodes for the reverse reads.',
         'forward_cut': 'Remove the specified number of bases from the forward '
-                       'sequences. Bases are removed before demultiplexing. If '
-                       'a positive value is provided, bases are removed from '
-                       'the beginning of the sequences. If a negative value is '
-                       'provided, bases are removed from the end of the '
-                       'sequences',
-        'reverse_cut': 'Remove the specified number of bases from the reverse '
-                       'sequences. Bases are removed before demultiplexing. If '
-                       'a positive value is provided, bases are removed from '
-                       'the beginning of the sequences. If a negative value is '
-                       'provided, bases are removed from the end of the '
-                       'sequences',
+                       'sequences. Bases are removed before demultiplexing. '
+                       'If a positive value is provided, bases are removed '
+                       'from the beginning of the sequences. If a negative '
+                       'value is provided, bases are removed from the end of '
+                       'the sequences',
+        'reverse_cut': 'Remove the specified number of bases from the forward '
+                       'sequences. Bases are removed before demultiplexing. '
+                       'If a positive value is provided, bases are removed '
+                       'from the beginning of the sequences. If a negative '
+                       'value is provided, bases are removed from the end of '
+                       'the sequences',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -347,13 +347,17 @@ plugin.methods.register_function(
                        'If a positive value is provided, bases are removed '
                        'from the beginning of the sequences. If a negative '
                        'value is provided, bases are removed from the end of '
-                       'the sequences',
+                       'the sequences. If --p-mixed-orientation is set, then '
+                       'both --p-forward-cut and --p-reverse-cut must both be '
+                       'set to the same value.',
         'reverse_cut': 'Remove the specified number of bases from the reverse '
                        'sequences. Bases are removed before demultiplexing. '
                        'If a positive value is provided, bases are removed '
                        'from the beginning of the sequences. If a negative '
                        'value is provided, bases are removed from the end of '
-                       'the sequences',
+                       'the sequences. If --p-mixed-orientation is set, then '
+                       'both --p-forward-cut and --p-reverse-cut must both be '
+                       'set to the same value.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -265,7 +265,7 @@ plugin.methods.register_function(
                                     inclusive_end=True),
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
-        'cut': Int % Range(None),
+        'cut': Int,
         'cores': Int % Range(1, None),
     },
     outputs=[
@@ -320,11 +320,12 @@ plugin.methods.register_function(
     parameters={
         'forward_barcodes': MetadataColumn[Categorical],
         'reverse_barcodes': MetadataColumn[Categorical],
+        'forward_cut': Int,
+        'reverse_cut': Int,
         'error_rate': Float % Range(0, 1, inclusive_start=True,
                                     inclusive_end=True),
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
-        'cut': Int % Range(None),
         'mixed_orientation': Bool,
         'cores': Int % Range(1, None),
     },
@@ -341,6 +342,18 @@ plugin.methods.register_function(
                             'per-sample barcodes for the forward reads.',
         'reverse_barcodes': 'The sample metadata column listing the '
                             'per-sample barcodes for the reverse reads.',
+        'forward_cut': 'Remove the specified number of bases from the forward '
+                       'sequences. Bases are removed before demultiplexing. If '
+                       'a positive value is provided, bases are removed from '
+                       'the beginning of the sequences. If a negative value is '
+                       'provided, bases are removed from the end of the '
+                       'sequences',
+        'reverse_cut': 'Remove the specified number of bases from the reverse '
+                       'sequences. Bases are removed before demultiplexing. If '
+                       'a positive value is provided, bases are removed from '
+                       'the beginning of the sequences. If a negative value is '
+                       'provided, bases are removed from the end of the '
+                       'sequences',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '
@@ -352,11 +365,6 @@ plugin.methods.register_function(
                           'the cutadapt default of 0 has been overridden, '
                           'because that value produces empty sequence '
                           'records.',
-        'cut': 'Remove the specified number of bases from the sequences. Bases'
-               'are removed before demultiplexing. If a positive value is'
-               'provided, bases are removed from the beginning of the '
-               'sequences. If a negative value is provided, bases are removed '
-               'from the end of the sequences',
         'mixed_orientation': 'Handle demultiplexing of mixed orientation '
                              'reads (i.e. when forward and reverse reads '
                              'coexist in the same file).',

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -265,6 +265,7 @@ plugin.methods.register_function(
                                     inclusive_end=True),
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
+        'cut': Int % Range(None),
         'cores': Int % Range(1, None),
     },
     outputs=[
@@ -291,6 +292,11 @@ plugin.methods.register_function(
                           'the cutadapt default of 0 has been overridden, '
                           'because that value produces empty sequence '
                           'records.',
+        'cut': 'Remove the specified number of bases from the sequences. Bases'
+               'are removed before demultiplexing. If a positive value is'
+               'provided, bases are removed from the beginning of the '
+               'sequences. If a negative value is provided, bases are removed '
+               'from the end of the sequences',
     },
     output_descriptions={
         'per_sample_sequences': 'The resulting demultiplexed sequences.',
@@ -318,6 +324,7 @@ plugin.methods.register_function(
                                     inclusive_end=True),
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
+        'cut': Int % Range(None),
         'mixed_orientation': Bool,
         'cores': Int % Range(1, None),
     },
@@ -345,9 +352,14 @@ plugin.methods.register_function(
                           'the cutadapt default of 0 has been overridden, '
                           'because that value produces empty sequence '
                           'records.',
+        'cut': 'Remove the specified number of bases from the sequences. Bases'
+               'are removed before demultiplexing. If a positive value is'
+               'provided, bases are removed from the beginning of the '
+               'sequences. If a negative value is provided, bases are removed '
+               'from the end of the sequences',
         'mixed_orientation': 'Handle demultiplexing of mixed orientation '
                              'reads (i.e. when forward and reverse reads '
-                             'coexist in the same file).'
+                             'coexist in the same file).',
     },
     output_descriptions={
         'per_sample_sequences': 'The resulting demultiplexed sequences.',

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -348,7 +348,7 @@ plugin.methods.register_function(
                        'from the beginning of the sequences. If a negative '
                        'value is provided, bases are removed from the end of '
                        'the sequences',
-        'reverse_cut': 'Remove the specified number of bases from the forward '
+        'reverse_cut': 'Remove the specified number of bases from the reverse '
                        'sequences. Bases are removed before demultiplexing. '
                        'If a positive value is provided, bases are removed '
                        'from the beginning of the sequences. If a negative '

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -807,8 +807,8 @@ class TestDemuxUtilsSingleEnd(TestPluginBase):
             self.assertTrue(str(self.untrimmed_dir_fmt) in obs[10])
             self.assertEqual(str(self.seqs_dir_fmt.file.view(FastqGzFormat)),
                              obs[11])
-            self.assertTrue('0' in obs[13])
-            self.assertTrue('1' in obs[15])
+            self.assertTrue('0' in obs[13])  # fwd cut
+            self.assertTrue('1' in obs[15])  # cores
 
     def test_rename_files_single(self):
         for fn in ['sample_a.1.fastq.gz', 'sample_b.1.fastq.gz']:
@@ -901,8 +901,9 @@ class TestDemuxUtilsPairedEnd(TestPluginBase):
         self.assertEqual(exp_f, obs[15])
         exp_r = str(self.seqs_dir_fmt.reverse_sequences.view(FastqGzFormat))
         self.assertEqual(exp_r, obs[16])
-        self.assertEqual('0', obs[18])
-        self.assertEqual('0', obs[20])
+        self.assertEqual('0', obs[18])  # rev cut
+        self.assertEqual('0', obs[20])  # fwd cut
+        self.assertEqual('1', obs[22])  # cores
 
     def test_build_dual_index_demux_command(self):
         with tempfile.NamedTemporaryFile() as barcode_fasta_f:

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -667,6 +667,18 @@ class TestDemuxPaired(TestPluginBase):
                                  reverse_barcodes=reverse_barcodes,
                                  mixed_orientation=True)
 
+    def test_mixed_different_cuts(self):
+        forward_barcodes = CategoricalMetadataColumn(
+            pd.Series(['AAAA', 'CCCC'], name='ForwardBarcode',
+                      index=pd.Index(['sample_a', 'sample_b'], name='id')))
+
+        with self.assertRaises(ValueError):
+            self.demux_paired_fn(self.muxed_sequences,
+                                 forward_barcodes=forward_barcodes,
+                                 forward_cut=4,
+                                 reverse_cut=2,
+                                 mixed_orientation=True)
+
 
 class TestDemuxUtilsSingleEnd(TestPluginBase):
     package = 'q2_cutadapt.tests'

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -901,6 +901,8 @@ class TestDemuxUtilsPairedEnd(TestPluginBase):
         self.assertEqual(exp_f, obs[15])
         exp_r = str(self.seqs_dir_fmt.reverse_sequences.view(FastqGzFormat))
         self.assertEqual(exp_r, obs[16])
+        self.assertEqual('0', obs[18])
+        self.assertEqual('0', obs[20])
 
     def test_build_dual_index_demux_command(self):
         with tempfile.NamedTemporaryFile() as barcode_fasta_f:

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -476,6 +476,42 @@ class TestDemuxPaired(TestPluginBase):
         self.assert_demux_results(metadata.to_series(), exp, obs_demuxed_art)
         self.assert_untrimmed_results(exp_untrimmed, obs_untrimmed_art)
 
+    def test_cut(self):
+        metadata = CategoricalMetadataColumn(
+            pd.Series(['AAAA', 'CCCC'], name='Barcode',
+                      index=pd.Index(['sample_a', 'sample_b'], name='id')))
+        exp = [
+            # sample a, fwd
+            '@id1\nCGTACGT\n+\nzzzzzzz\n'
+            '@id3\nCGTACGT\n+\nzzzzzzz\n',
+            # sample a, rev
+            '@id1\nGGGGTGCATG\n+\nzzzzzzzzzz\n'
+            '@id3\nGGGGTGCATG\n+\nzzzzzzzzzz\n',
+            # sample b, fwd
+            '@id2\nACGTACGT\n+\nzzzzzzzz\n'
+            '@id4\nACGTACGT\n+\nzzzzzzzz\n'
+            '@id5\nACGTACGT\n+\nzzzzzzzz\n',
+            # sample b, rev
+            '@id2\nTTTTTGCATG\n+\nzzzzzzzzzz\n'
+            '@id4\nTTTTTGCATG\n+\nzzzzzzzzzz\n'
+            '@id5\nTTTTTGCATG\n+\nzzzzzzzzzz\n', ]
+        exp_untrimmed = [
+            '@id6\nGGGACGTACGT\n+\nzzzzzzzzzzz\n',
+            '@id6\nTTTTTGCATG\n+\nzzzzzzzzzz\n'
+        ]
+
+        # Test a positive cut in forward sequences and a negative cut in
+        #  reverse at the same time
+        with redirected_stdio(stderr=os.devnull):
+            obs_demuxed_art, obs_untrimmed_art = \
+                self.demux_paired_fn(self.muxed_sequences,
+                                     forward_barcodes=metadata,
+                                     forward_cut=1,
+                                     reverse_cut=-2)
+
+        self.assert_demux_results(metadata.to_series(), exp, obs_demuxed_art)
+        self.assert_untrimmed_results(exp_untrimmed, obs_untrimmed_art)
+
     def test_dual_index_success(self):
         forward_barcodes = CategoricalMetadataColumn(
             pd.Series(['AAAA', 'CCCC'], name='ForwardBarcode',

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -316,7 +316,7 @@ class TestDemuxSingle(TestPluginBase):
         self.assert_demux_results(metadata.to_series(), exp, obs_demuxed_art)
         self.assert_untrimmed_results('', obs_untrimmed_art)
 
-    def test_cut(self):
+    def test_cut_positive(self):
         metadata = CategoricalMetadataColumn(
             pd.Series(['AAAA', 'CCCC'], name='Barcode',
                       index=pd.Index(['sample_a', 'sample_b'], name='id')))
@@ -339,6 +339,31 @@ class TestDemuxSingle(TestPluginBase):
         with redirected_stdio(stderr=os.devnull):
             obs_demuxed_art, obs_untrimmed_art = \
                 self.demux_single_fn(self.muxed_sequences, metadata, cut=1)
+
+        self.assert_demux_results(metadata.to_series(), exp, obs_demuxed_art)
+        self.assert_untrimmed_results(exp_untrimmed, obs_untrimmed_art)
+
+    def test_cut_negative(self):
+        metadata = CategoricalMetadataColumn(
+            pd.Series(['AAAA', 'CCCC'], name='Barcode',
+                      index=pd.Index(['sample_a', 'sample_b'], name='id')))
+        # Expected demux and untrimmed sequences are the same as in
+        #  `test_typical`, only shortened of their last two nucleotides.
+        exp = [
+            # sample a
+            '@id1\nACGTAC\n+\nzzzzzz\n'
+            '@id3\nACGTAC\n+\nzzzzzz\n',
+            # sample b
+            '@id2\nACGTAC\n+\nzzzzzz\n'
+            '@id4\nACGTAC\n+\nzzzzzz\n'
+            '@id5\nACGTAC\n+\nzzzzzz\n', ]
+
+        exp_untrimmed = \
+            '@id6\nGGGGACGTAC\n+\nzzzzzzzzzz\n'
+
+        with redirected_stdio(stderr=os.devnull):
+            obs_demuxed_art, obs_untrimmed_art = \
+                self.demux_single_fn(self.muxed_sequences, metadata, cut=-2)
 
         self.assert_demux_results(metadata.to_series(), exp, obs_demuxed_art)
         self.assert_untrimmed_results(exp_untrimmed, obs_untrimmed_art)


### PR DESCRIPTION
Allow to use cutadapt `--cut` option

This is useful in combination with anchored adapters (https://cutadapt.readthedocs.io/en/stable/guide.html#anchored-5adapters) when a poly-N is added before the tag/index/primer to increase Illumina sequences discrimination during its clustering phase

A follow-up pull request that adds an "anchored" mode will follow if this request is accepted