### PR TITLE
Anchor barcodes during demultiplexing

### DIFF
--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -61,7 +61,6 @@ def _build_demux_command(seqs_dir_fmt, barcode_fhs, per_sample_dir_fmt,
             cmd += [
                 '--pair-adapters',
                 '-G',
-                # pylint: disable-next=line-too-long  # Increase readability
                 f'{"^" if anchor_reverse else ""}file:{barcode_fhs["rev"].name}',  # noqa: E501
             ]
         cmd += [

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -44,7 +44,7 @@ def _build_demux_command(seqs_dir_fmt, barcode_fhs, per_sample_dir_fmt,
                          anchor_forward=False, anchor_reverse=False,
                          cores=1):
     cmd = ['cutadapt',
-           '--front',
+           '-g',
            f'{"^" if anchor_forward else ""}file:{barcode_fhs["fwd"].name}',
            '--error-rate', str(error_rate),
            '--minimum-length', str(minimum_length),

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -62,7 +62,7 @@ def _build_demux_command(seqs_dir_fmt, barcode_fhs, per_sample_dir_fmt,
                 '--pair-adapters',
                 '-G',
                 # pylint: disable-next=line-too-long  # Increase readability
-                f'{"^" if anchor_reverse else ""}file:{barcode_fhs["rev"].name}',
+                f'{"^" if anchor_reverse else ""}file:{barcode_fhs["rev"].name}',  # noqa: E501
             ]
         cmd += [
             '-p', os.path.join(str(per_sample_dir_fmt), '{name}.2.fastq.gz'),

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -291,7 +291,16 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
     ):
         raise ValueError("'forward_cut' and 'reverse_cut' need to be set to "
                          "the same number when using the 'mixed_orientation' "
-                         "mode")
+                         "mode.")
+
+    if (
+        mixed_orientation
+        and anchor_forward_barcode != anchor_reverse_barcode
+    ):
+        raise ValueError(
+            "'anchor_forward_barcode' and 'anchor_reverse_barcode' need to be "
+            "set to the same value when using the 'mixed_orientation' mode."
+        )
 
     per_sample_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     mux_fmt = MultiplexedPairedEndBarcodeInSequenceDirFmt

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -300,7 +300,6 @@ def _check_paired_requirements(loc):
         )
 
 
-
 def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
                  forward_barcodes: qiime2.CategoricalMetadataColumn,
                  reverse_barcodes: qiime2.CategoricalMetadataColumn = None,

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -268,22 +268,13 @@ def demux_single(seqs: MultiplexedSingleEndBarcodeInSequenceDirFmt,
     return per_sample_sequences, untrimmed
 
 
-def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
-                 forward_barcodes: qiime2.CategoricalMetadataColumn,
-                 reverse_barcodes: qiime2.CategoricalMetadataColumn = None,
-                 forward_cut: int = 0,
-                 reverse_cut: int = 0,
-                 anchor_forward_barcode: bool = False,
-                 anchor_reverse_barcode: bool = False,
-                 error_rate: float = 0.1,
-                 batch_size: int = 0,
-                 minimum_length: int = 1,
-                 mixed_orientation: bool = False,
-                 cores: int = 1) -> \
-                    (CasavaOneEightSingleLanePerSampleDirFmt,
-                     MultiplexedPairedEndBarcodeInSequenceDirFmt):
-    _check_barcodes_uniqueness(
-        forward_barcodes, reverse_barcodes, mixed_orientation)
+def _check_paired_requirements(loc):
+    mixed_orientation = loc.get("mixed_orientation", None)
+    forward_cut = loc.get("forward_cut", 0)
+    reverse_cut = loc.get("reverse_cut", 0)
+    reverse_barcodes = loc.get("reverse_barcodes", None)
+    anchor_forward_barcode = loc.get("anchor_forward_barcode", False)
+    anchor_reverse_barcode = loc.get("anchor_reverse_barcode", False)
 
     if (
         not mixed_orientation
@@ -308,6 +299,26 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
             "'anchor_forward_barcode' and 'anchor_reverse_barcode' need to be "
             "set to the same value when using the 'mixed_orientation' mode."
         )
+
+
+
+def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
+                 forward_barcodes: qiime2.CategoricalMetadataColumn,
+                 reverse_barcodes: qiime2.CategoricalMetadataColumn = None,
+                 forward_cut: int = 0,
+                 reverse_cut: int = 0,
+                 anchor_forward_barcode: bool = False,
+                 anchor_reverse_barcode: bool = False,
+                 error_rate: float = 0.1,
+                 batch_size: int = 0,
+                 minimum_length: int = 1,
+                 mixed_orientation: bool = False,
+                 cores: int = 1) -> \
+                    (CasavaOneEightSingleLanePerSampleDirFmt,
+                     MultiplexedPairedEndBarcodeInSequenceDirFmt):
+    _check_barcodes_uniqueness(
+        forward_barcodes, reverse_barcodes, mixed_orientation)
+    _check_paired_requirements(locals())
 
     per_sample_sequences = CasavaOneEightSingleLanePerSampleDirFmt()
     mux_fmt = MultiplexedPairedEndBarcodeInSequenceDirFmt

--- a/q2_cutadapt/_demux.py
+++ b/q2_cutadapt/_demux.py
@@ -286,6 +286,13 @@ def demux_paired(seqs: MultiplexedPairedEndBarcodeInSequenceDirFmt,
         forward_barcodes, reverse_barcodes, mixed_orientation)
 
     if (
+        not mixed_orientation
+        and anchor_reverse_barcode and (reverse_barcodes is None)
+    ):
+        raise ValueError("A reverse barcode needs to be provided in order to "
+                         "anchor the reverse barcode.")
+
+    if (
         mixed_orientation
         and forward_cut != reverse_cut
     ):

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -263,6 +263,7 @@ plugin.methods.register_function(
         'barcodes': MetadataColumn[Categorical],
         'error_rate': Float % Range(0, 1, inclusive_start=True,
                                     inclusive_end=True),
+        'anchor_barcode': Bool,
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
         'cut': Int,
@@ -283,6 +284,9 @@ plugin.methods.register_function(
                       'allowable error rate. The default value specified by '
                       'cutadapt is 0.1 (=10%), which is greater than '
                       '`demux emp-*`, which is 0.0 (=0%).',
+        'anchor_barcode': 'Anchor the barcode. An anchored barcode is '
+                          'expected to occur in full length at the beginning '
+                          'of the sequence. Can fasten demultiplexing if used.',
         'batch_size': 'The number of samples cutadapt demultiplexes '
                       'concurrently. Demultiplexing in smaller batches will '
                       'yield the same result with marginal speed loss, and '
@@ -324,6 +328,8 @@ plugin.methods.register_function(
         'reverse_cut': Int,
         'error_rate': Float % Range(0, 1, inclusive_start=True,
                                     inclusive_end=True),
+        'anchor_forward_barcode': Bool,
+        'anchor_reverse_barcode': Bool,
         'batch_size': Int % Range(0, None),
         'minimum_length': Int % Range(1, None),
         'mixed_orientation': Bool,
@@ -358,6 +364,14 @@ plugin.methods.register_function(
                        'the sequences. If --p-mixed-orientation is set, then '
                        'both --p-forward-cut and --p-reverse-cut must be '
                        'set to the same value.',
+        'anchor_forward_barcode': 'Anchor the forward barcode. An anchored '
+                                  'barcode is expected to occur in full '
+                                  'length at the beginning of the sequence. '
+                                  'Can fasten demultiplexing if used.',
+        'anchor_reverse_barcode': 'Anchor the reverse barcode. An anchored '
+                                  'barcode is expected to occur in full '
+                                  'length at the beginning of the sequence. '
+                                  'Can fasten demultiplexing if used.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -286,8 +286,8 @@ plugin.methods.register_function(
                       '`demux emp-*`, which is 0.0 (=0%).',
         'anchor_barcode': 'Anchor the barcode. The barcode is then '
                           'expected to occur in full length at the beginning '
-                          '(5\' end) of the sequence. Can speed up demultiplexing '
-                          'if used.',
+                          '(5\' end) of the sequence. Can speed up '
+                          'demultiplexing if used.',
         'batch_size': 'The number of samples cutadapt demultiplexes '
                       'concurrently. Demultiplexing in smaller batches will '
                       'yield the same result with marginal speed loss, and '
@@ -367,12 +367,14 @@ plugin.methods.register_function(
                        'set to the same value.',
         'anchor_forward_barcode': 'Anchor the forward barcode. The '
                                   'barcode is then expected to occur in full '
-                                  'length at the beginning (5\' end) of the forward '
-                                  'sequence. Can speed up demultiplexing if used.',
+                                  'length at the beginning (5\' end) of the '
+                                  'forward sequence. Can speed up '
+                                  'demultiplexing if used.',
         'anchor_reverse_barcode': 'Anchor the reverse barcode. The '
                                   'barcode is then expected to occur in full '
-                                  'length at the beginning (5\' end) of the reverse '
-                                  'sequence. Can speed up demultiplexing if used.',
+                                  'length at the beginning (5\' end) of the '
+                                  'reverse sequence. Can speed up '
+                                  'demultiplexing if used.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -286,7 +286,8 @@ plugin.methods.register_function(
                       '`demux emp-*`, which is 0.0 (=0%).',
         'anchor_barcode': 'Anchor the barcode. An anchored barcode is '
                           'expected to occur in full length at the beginning '
-                          'of the sequence. Can fasten demultiplexing if used.',
+                          'of the sequence. Can fasten demultiplexing if '
+                          'used.',
         'batch_size': 'The number of samples cutadapt demultiplexes '
                       'concurrently. Demultiplexing in smaller batches will '
                       'yield the same result with marginal speed loss, and '

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -297,11 +297,11 @@ plugin.methods.register_function(
                           'the cutadapt default of 0 has been overridden, '
                           'because that value produces empty sequence '
                           'records.',
-        'cut': 'Remove the specified number of bases from the sequences. Bases'
-               'are removed before demultiplexing. If a positive value is'
-               'provided, bases are removed from the beginning of the '
+        'cut': 'Remove the specified number of bases from the sequences. '
+               'Bases are removed before demultiplexing. If a positive value '
+               'is provided, bases are removed from the beginning of the '
                'sequences. If a negative value is provided, bases are removed '
-               'from the end of the sequences',
+               'from the end of the sequences.',
     },
     output_descriptions={
         'per_sample_sequences': 'The resulting demultiplexed sequences.',

--- a/q2_cutadapt/plugin_setup.py
+++ b/q2_cutadapt/plugin_setup.py
@@ -284,10 +284,10 @@ plugin.methods.register_function(
                       'allowable error rate. The default value specified by '
                       'cutadapt is 0.1 (=10%), which is greater than '
                       '`demux emp-*`, which is 0.0 (=0%).',
-        'anchor_barcode': 'Anchor the barcode. An anchored barcode is '
+        'anchor_barcode': 'Anchor the barcode. The barcode is then '
                           'expected to occur in full length at the beginning '
-                          'of the sequence. Can fasten demultiplexing if '
-                          'used.',
+                          '(5\' end) of the sequence. Can speed up demultiplexing '
+                          'if used.',
         'batch_size': 'The number of samples cutadapt demultiplexes '
                       'concurrently. Demultiplexing in smaller batches will '
                       'yield the same result with marginal speed loss, and '
@@ -365,14 +365,14 @@ plugin.methods.register_function(
                        'the sequences. If --p-mixed-orientation is set, then '
                        'both --p-forward-cut and --p-reverse-cut must be '
                        'set to the same value.',
-        'anchor_forward_barcode': 'Anchor the forward barcode. An anchored '
-                                  'barcode is expected to occur in full '
-                                  'length at the beginning of the sequence. '
-                                  'Can fasten demultiplexing if used.',
-        'anchor_reverse_barcode': 'Anchor the reverse barcode. An anchored '
-                                  'barcode is expected to occur in full '
-                                  'length at the beginning of the sequence. '
-                                  'Can fasten demultiplexing if used.',
+        'anchor_forward_barcode': 'Anchor the forward barcode. The '
+                                  'barcode is then expected to occur in full '
+                                  'length at the beginning (5\' end) of the forward '
+                                  'sequence. Can speed up demultiplexing if used.',
+        'anchor_reverse_barcode': 'Anchor the reverse barcode. The '
+                                  'barcode is then expected to occur in full '
+                                  'length at the beginning (5\' end) of the reverse '
+                                  'sequence. Can speed up demultiplexing if used.',
         'error_rate': 'The level of error tolerance, specified as the maximum '
                       'allowable error rate.',
         'batch_size': 'The number of samples cutadapt demultiplexes '

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -618,7 +618,7 @@ class TestDemuxPaired(TestPluginBase):
             '@id2\nACGTACGT\n+\nzzzzzzzz\n'
             '@id4\nACGTACGT\n+\nzzzzzzzz\n'
             '@id5\nACGTACGT\n+\nzzzzzzzz\n',
-            # sample a, rev
+            # sample b, rev
             '@id2\nTGCATGCA\n+\nzzzzzzzz\n'
             '@id4\nTGCATGCA\n+\nzzzzzzzz\n'
             '@id5\nTGCATGCA\n+\nzzzzzzzz\n', ]
@@ -729,7 +729,7 @@ class TestDemuxPaired(TestPluginBase):
             '@id2\nACGTACGT\n+\nzzzzzzzz\n'
             '@id4\nACGTACGT\n+\nzzzzzzzz\n'
             '@id5\nACGTACGT\n+\nzzzzzzzz\n',
-            # sample a, rev
+            # sample b, rev
             '@id2\nTGCATGCA\n+\nzzzzzzzz\n'
             '@id4\nTGCATGCA\n+\nzzzzzzzz\n'
             '@id5\nTGCATGCA\n+\nzzzzzzzz\n', ]

--- a/q2_cutadapt/tests/test_demux.py
+++ b/q2_cutadapt/tests/test_demux.py
@@ -801,6 +801,71 @@ class TestDemuxPaired(TestPluginBase):
         # Everything should match, so untrimmed should be empty
         self.assert_untrimmed_results(['', ''], obs_untrimmed_art)
 
+    def test_mixed_orientation_anchored(self):
+        # sample_a and sample_b have reads in both fwd and rev directions.
+        # sample_c only has reads in the fwd direction.
+        # sample_d only has reads in the rev direction.
+        forward_barcodes = CategoricalMetadataColumn(
+            pd.Series(['AAAA', 'CCCA', 'GGGG', 'TTTA'], name='ForwardBarcode',
+                      index=pd.Index(['sample_a', 'sample_b', 'sample_c',
+                                      'sample_d'], name='id')))
+        mixed_orientation_sequences_f_fp = self.get_data_path(
+            'mixed-orientation/forward.fastq.gz')
+        mixed_orientation_sequences_r_fp = self.get_data_path(
+            'mixed-orientation/reverse.fastq.gz')
+        with tempfile.TemporaryDirectory() as temp:
+            shutil.copy(mixed_orientation_sequences_f_fp, temp)
+            shutil.copy(mixed_orientation_sequences_r_fp, temp)
+            mixed_orientation_sequences = Artifact.import_data(
+                'MultiplexedPairedEndBarcodeInSequence', temp)
+
+        with redirected_stdio(stderr=os.devnull):
+            obs_demuxed_art, obs_untrimmed_art = \
+                self.demux_paired_fn(mixed_orientation_sequences,
+                                     forward_barcodes=forward_barcodes,
+                                     anchor_forward_barcode=True,
+                                     anchor_reverse_barcode=True,
+                                     mixed_orientation=True)
+        exp = [
+            # sample_a fwd
+            '@id1\nACGTACGT\n+\nyyyyyyyy\n'
+            '@id3\nACGTACGT\n+\nyyyyyyyy\n',
+            # sample_a rev
+            '@id1\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n'
+            '@id3\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n',
+            # sample_b fwd is empty because the first 'C' from the sequence is
+            #  not in the barcode (sequence is 'CCCCACGTACGT')
+            '',
+            # sample_b rev is empty for the same reason
+            '',
+            # sample_c fwd
+            '@id5\nACGTACGT\n+\nyyyyyyyy\n',
+            # sample_c rev
+            '@id5\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n',
+            # sample_d fwd is empty cf. sample_b
+            '',
+            # sample_d rev is empty cf. sample_b
+            '',
+        ]
+        exp_untrimmed = [
+            '@id2\nCCCCACGTACGT\n+\nyyyyyyyyyyyy\n'
+            '@id4\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n'
+            '@id6\nTTTTACGTACGT\n+\nyyyyyyyyyyyy\n',
+            '@id2\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n'
+            '@id4\nCCCCACGTACGT\n+\nyyyyyyyyyyyy\n'
+            '@id6\nTGCATGCATGCA\n+\nzzzzzzzzzzzz\n'
+        ]
+
+        # We want to be sure that the validation is 100%, not just `min`,
+        obs_demuxed_art.validate(level='max')
+        # checkpoint assertion for the above `validate` - nothing should fail
+        self.assertTrue(True)
+
+        self.assert_demux_results(forward_barcodes.to_series(), exp,
+                                  obs_demuxed_art)
+
+        self.assert_untrimmed_results(exp_untrimmed, obs_untrimmed_art)
+
     def test_dual_index_mismatched_barcodes(self):
         forward_barcodes = CategoricalMetadataColumn(
             pd.Series(['AAAA', 'CCCC', 'ACGT'], name='ForwardBarcode',


### PR DESCRIPTION
Follow up of the pull request #57

Allow to anchor barcodes for demultiplexing, which can be useful when used in combination with the `--cut` parameter.

Overview of the kind of problems it can solve:
When doing metabarcoding, it is sometimes advised to add a short poly-N (around 5) at the beginning of the sequence to increase Illumina sequence discrimination in the early phases of sequencing. 
However, cutadapt does not anchor barcodes by default, meaning that using cutadapt on sequence "RCODEacgt" with the barcode "BARCODE" will result in the demultiplexed sequence "acgt".
Given enough sequences, and the use of numerous short barcodes (such as an Illumina index of 8 bases) this can lead to the wrong assignation of many sequences, hindering downstream processes.
One simple solution is to first remove the poly-N (using the `--cut` option) and using anchored barcodes.
While it is possible to anchor this for each barcode individually by adding a `^` before the barcode, this can be cumbersome. This pull request uses cutadapt `^file:*` option to anchor all the barcodes at the same time